### PR TITLE
Fix extract_clean_sequence()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,6 +26,7 @@ Imports:
     curl,
     cli,
     crayon,
+    stringi
 Suggests:
     sessioninfo,
     MonetDBLite (>= 0.6.0),

--- a/R/extract-tools.R
+++ b/R/extract-tools.R
@@ -81,11 +81,32 @@ extract_seqrecpart <- function(record) {
 #' @title Extract clean sequence from sequence part
 #' @description Return clean sequence from seqrecpart of a GenBank record
 #' @param seqrecpart Sequence part of a GenBank record, character
+#' @param max_len Number: maximum number of characters allowed in a single
+#' record before splitting the record into parts. Does not affect output,
+#' but only internal calculations, so generally should not be changed.
+#' Default = 1e8.
 #' @details If element is not found, '' returned.
 #' @return character
 #' @family private
-extract_clean_sequence <- function(seqrecpart) {
-  seq <- gsub(pattern = '([0-9]|\\s+|\n|/)', replacement = '', x = seqrecpart)
+extract_clean_sequence <- function(seqrecpart, max_len = 1e8) {
+  # If number of chars in sequence part is too long for gsub(),
+  # split into chunks each no bigger than max_len chars
+  if (nchar(seqrecpart) > max_len) {
+    seqrecpart <- stringi::stri_sub(
+      seqrecpart,
+      seq(1, stringi::stri_length(seqrecpart),
+          by = max_len),
+      length = max_len
+    )
+  }
+  # Extract the DNA sequence from each part
+  seq <- paste0(
+    sapply(
+      seqrecpart,
+      function(x) gsub(pattern = '([0-9]|\\s+|\n|/)', replacement = '', x)
+    ),
+    collapse = ""
+  )
   # upper case is recommended, at least it is what rentrez returns
   toupper(seq)
 }


### PR DESCRIPTION
<!-- IF THIS INVOLVES AUTHENTICATION: DO NOT SHARE YOUR USERNAME/PASSWORD, OR API KEYS/TOKENS IN THIS ISSUE - MOST LIKELY THE MAINTAINER WILL HAVE THEIR OWN EQUIVALENT KEY -->

<!-- If you've updated a file in the man-roxygen directory, make sure to update the man/ files by running devtools::document() or similar as .Rd files should be affected by your change -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Since `gsub` [overflows on very long strings](https://bugs.r-project.org/show_bug.cgi?id=18346), this PR breaks long DNA sequences in the flatfile into chunks that are each less than a length likely to break `gsub()`.

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

Fixes #14 

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->

(none; doesn't add a new function so didn't write any new tests)

<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->


