### PR TITLE
Calculate db size using fs::fs_bytes()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,7 +38,8 @@ Imports:
     cli,
     crayon,
     stringi,
-    duckdb
+    duckdb,
+    fs
 Suggests:
     sessioninfo,
     testthat,

--- a/R/log-tools.R
+++ b/R/log-tools.R
@@ -243,7 +243,7 @@ dir_size <- function(fp) {
   fls <- file.path(fp, fls)
   totsz <- sum(vapply(X = fls, FUN = file.size, FUN.VALUE = double(1)),
                  na.rm = TRUE)
-  round(x = totsz / 1E9, digits = 2)
+  fs::fs_bytes(totsz)
 }
 
 #' @name gbrelease_check

--- a/R/status-tools.R
+++ b/R/status-tools.R
@@ -48,7 +48,7 @@ status_class <- function() {
   slctns <- paste0(slctn_get(), collapse = ', ')
   download_info <- list('Path' = flpth, 'Does path exist?' = dir.exists(flpth),
                         'N. files' = length(dwn_fls),
-                        'N. GBs' = dir_size(flpth),
+                        'Total size' = dir_size(flpth),
                         'GenBank division selections' = slctns,
                         'GenBank Release' = gbrelease_get(),
                         'Last updated' = last_dwnld_get())
@@ -57,7 +57,7 @@ status_class <- function() {
   sqlngths <- db_sqlngths_get()
   nseqs <- suppressWarnings(count_db_ids())
   database_info <- list('Path' = flpth, 'Does path exist?' = file.exists(flpth),
-                        'N. GBs' = dir_size(flpth),
+                        'Total size' = fs::fs_bytes(file.size(flpth)),
                         'Does the database have data?' = has_data(),
                         'Number of sequences' = nseqs,
                         'Min. sequence length' = sqlngths[['min']],

--- a/codemeta.json
+++ b/codemeta.json
@@ -211,9 +211,21 @@
       },
       "sameAs": "https://CRAN.R-project.org/package=duckdb"
     },
+    "10": {
+      "@type": "SoftwareApplication",
+      "identifier": "fs",
+      "name": "fs",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Comprehensive R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      },
+      "sameAs": "https://CRAN.R-project.org/package=fs"
+    },
     "SystemRequirements": null
   },
-  "fileSize": "1656.229KB",
+  "fileSize": "1658.17KB",
   "citation": [
     {
       "@type": "ScholarlyArticle",

--- a/tests/testthat/test-status-tools.R
+++ b/tests/testthat/test-status-tools.R
@@ -13,7 +13,11 @@ test_that('restez_status() works', {
   demo_db_create(n = 10)
   status_obj <- restez_status(gb_check = FALSE)
   expect_true(status_obj$Database$`Does path exist?`)
+  expect_equal(as.character(status_obj$Database$`Total size`), "1.01M")
   expect_true(status_obj$Database$`Does the database have data?`)
+  expect_equal(status_obj$Database$`Number of sequences`, 10)
+  expect_equal(status_obj$Database$`Min. sequence length`, "0")
+  expect_equal(status_obj$Database$`Max. sequence length`, "Inf")
 })
 test_that('status_class() works', {
   cleanup()


### PR DESCRIPTION
Fixes #32

Uses `fs::fs_bytes()` to calculate file size of download directory and duckdb database. This not only fixes the '0 gb' message, but makes sure that a meaningful file size will be shown even when the total is < 1 gb.